### PR TITLE
docs: add Bun usage instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,20 @@ yarn dev
 
 5. Open your browser and visit `http://localhost:5173`
 
+Alternatively, using [Bun](https://bun.sh/):
+
+```bash
+bun install
+bun run dev
+```
+
+Bun can also build and preview the app:
+
+```bash
+bun run build
+bun run preview
+```
+
 ## Building for Production
 
 To create a production version of your app:


### PR DESCRIPTION
## Summary
- document Bun install and dev commands
- mention Bun build and preview support

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run check` (fails: svelte-check found 4 errors and 8 warnings in 4 files)


------
https://chatgpt.com/codex/tasks/task_e_68adae1fd6108320b09efbe9e587193c