### PR TITLE
Ensure external links use noopener noreferrer

### DIFF
--- a/src/lib/components/Community.svelte
+++ b/src/lib/components/Community.svelte
@@ -31,10 +31,10 @@
 
         <CardFooter>
           <Button>
-            <a 
+            <a
               href="https://discord.com/"
               target="_blank"
-              rel="noreferrer"
+              rel="noopener noreferrer"
               class="w-full h-full"
             >
               Join Discord

--- a/src/lib/components/Footer.svelte
+++ b/src/lib/components/Footer.svelte
@@ -51,7 +51,7 @@
           target="_blank"
           href="https://github.com/leoMirandaa"
           class="text-primary transition-all border-primary hover:border-b-2"
-          rel="noreferrer"
+          rel="noopener noreferrer"
         >
           Leo Miranda
         </a>

--- a/src/lib/components/Hero.svelte
+++ b/src/lib/components/Hero.svelte
@@ -59,7 +59,7 @@
                     <a
                         href="https://github.com/Zxce3/shadcn-sveltekit-landing-page.git"
                         target="_blank"
-                        rel="noreferrer"
+                        rel="noopener noreferrer"
                     >
                         Github repository
                     </a>

--- a/src/lib/components/Navbar.svelte
+++ b/src/lib/components/Navbar.svelte
@@ -143,6 +143,7 @@
         aria-label="View on GitHub"
         href="https://github.com/zxce3/shadcn-sveltekit-landing-page.git"
         target="_blank"
+        rel="noopener noreferrer"
       >
         <GithubIcon class_="size-5" />
       </a>

--- a/src/lib/components/Teams.svelte
+++ b/src/lib/components/Teams.svelte
@@ -212,6 +212,7 @@
             <a
               href={url}
               target="_blank"
+              rel="noopener noreferrer"
               class="hover:opacity-80 transition-opacity"
               aria-label="Visit our {name} page"
             >


### PR DESCRIPTION
## Summary
- Add `rel="noopener noreferrer"` to GitHub link in Navbar
- Replace `rel="noreferrer"` with `rel="noopener noreferrer"` in Footer
- Update other components so all external links include `rel="noopener noreferrer"`

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run check` *(fails: svelte-check found 4 errors and 8 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68adae1fb4e083208aca69435fa05e53