### PR TITLE
chore: add vitest test setup

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "preview": "vite preview",
     "prepare": "svelte-kit sync || echo ''",
     "check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
-    "check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch"
+    "check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
+    "test": "vitest"
   },
   "devDependencies": {
     "@internationalized/date": "^3.7.0",
@@ -19,11 +20,14 @@
     "@tailwindcss/container-queries": "^0.1.1",
     "@tailwindcss/forms": "^0.5.10",
     "@tailwindcss/typography": "^0.5.16",
+    "@testing-library/jest-dom": "^6.8.0",
+    "@testing-library/svelte": "^5.2.8",
     "autoprefixer": "^10.4.20",
     "bits-ui": "^1.3.0",
     "clsx": "^2.1.1",
     "embla-carousel-svelte": "^8.5.2",
     "formsnap": "^2.0.0",
+    "jsdom": "^26.1.0",
     "lucide-svelte": "^0.475.0",
     "mode-watcher": "^0.5.1",
     "paneforge": "^1.0.0-next.4",
@@ -38,6 +42,7 @@
     "typescript": "^5.0.0",
     "vaul-svelte": "^1.0.0-next.6",
     "vite": "^6.0.0",
+    "vitest": "^3.2.4",
     "zod": "^3.24.2"
   },
   "dependencies": {

--- a/src/lib/__tests__/utils.test.ts
+++ b/src/lib/__tests__/utils.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from 'vitest';
+import { cn } from '../utils.js';
+
+describe('cn', () => {
+        it('merges class names', () => {
+                expect(cn('px-2', 'py-3')).toBe('px-2 py-3');
+        });
+
+        it('resolves conflicting classes', () => {
+                expect(cn('p-2', 'p-4')).toBe('p-4');
+        });
+});

--- a/src/lib/components/ui/button/button.test.ts
+++ b/src/lib/components/ui/button/button.test.ts
@@ -1,0 +1,11 @@
+import { render } from '@testing-library/svelte';
+import { describe, expect, it } from 'vitest';
+import Button from './button.svelte';
+
+describe('Button', () => {
+        it('renders a button element', () => {
+                const { getByRole } = render(Button);
+                const button = getByRole('button');
+                expect(button).toBeInTheDocument();
+        });
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,5 +2,13 @@ import { sveltekit } from '@sveltejs/kit/vite';
 import { defineConfig } from 'vite';
 
 export default defineConfig({
-	plugins: [sveltekit()]
+        plugins: [sveltekit()],
+        test: {
+                environment: 'jsdom',
+                globals: true,
+                setupFiles: ['./vitest.setup.ts']
+        },
+        resolve: {
+                conditions: ['browser', 'development']
+        }
 });

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';


### PR DESCRIPTION
## Summary
- configure Vitest and add testing libraries
- test utility `cn` and button component

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68adae09647083209bfcc1da919d0819